### PR TITLE
build with numpy < 1.20

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -6,12 +6,6 @@ set -e -x
 # build based on python version from args
 PYTHON_VERSION="$1"
 case $PYTHON_VERSION in
-2.7)
-  PYBIN="/opt/python/cp27-cp27m/bin"
-  ;;
-3.5)
-  PYBIN="/opt/python/cp35-cp35m/bin"
-  ;;
 3.6)
   PYBIN="/opt/python/cp36-cp36m/bin"
   ;;
@@ -20,6 +14,9 @@ case $PYTHON_VERSION in
   ;;
 3.8)
   PYBIN="/opt/python/cp38-cp38/bin"
+  ;;
+3.9)
+  PYBIN="/opt/python/cp39-cp39/bin"
   ;;
 esac
 

--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -13,7 +13,7 @@ jobs:
     name: Mac OS Unit Testing
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     env:
       SHELLOPTS: 'errexit:pipefail'
@@ -51,8 +51,8 @@ jobs:
           twine check dist/*
 
       - name: Upload to PyPi
-        if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+        if: startsWith(github.event.ref, 'refs/tags')
         run: |
-          twine upload -u __token__ --skip-existing dist/scooby*
+          twine upload -u __token__ --skip-existing dist/*
         env:
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -3,9 +3,6 @@ pyacvd
 .. image:: https://img.shields.io/pypi/v/pyacvd.svg
     :target: https://pypi.org/project/pyacvd/
 
-.. image:: https://travis-ci.org/pyvista/pyacvd.svg?branch=master
-    :target: https://travis-ci.org/pyvista/pyacvd
-
 
 This module takes a surface mesh and returns a uniformly meshed surface using voronoi clustering.  This approach is loosely based on research by S. Valette, and J. M. Chassery in `ACVD <https://github.com/valette/ACVD>`_.
 
@@ -32,10 +29,10 @@ This example remeshes a non-uniform quad mesh into a uniform triangular mesh.
     # plot original mesh
     cow.plot(show_edges=True, color='w')
 
-.. image:: https://github.com/pyvista/pyacvd/raw/master/docs/images/cow.png
+.. image:: https://github.com/pyvista/pyacvd/raw/main/docs/images/cow.png
     :alt: original cow mesh
 
-.. image:: https://github.com/pyvista/pyacvd/raw/master/docs/images/cow_zoom.png
+.. image:: https://github.com/pyvista/pyacvd/raw/main/docs/images/cow_zoom.png
     :alt: zoomed cow mesh
 
 .. code:: python
@@ -48,7 +45,7 @@ This example remeshes a non-uniform quad mesh into a uniform triangular mesh.
     # plot clustered cow mesh
     clus.plot()
 
-.. image:: https://github.com/pyvista/pyacvd/raw/master/docs/images/cow_clus.png
+.. image:: https://github.com/pyvista/pyacvd/raw/main/docs/images/cow_clus.png
     :alt: zoomed cow mesh
 
 .. code:: python
@@ -59,5 +56,5 @@ This example remeshes a non-uniform quad mesh into a uniform triangular mesh.
     # plot uniformly remeshed cow
     remesh.plot(color='w', show_edges=True)
 
-.. image:: https://github.com/pyvista/pyacvd/raw/master/docs/images/cow_remesh.png
+.. image:: https://github.com/pyvista/pyacvd/raw/main/docs/images/cow_remesh.png
     :alt: zoomed cow mesh

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
@@ -56,6 +58,8 @@ jobs:
         python.version: '3.7'
       Python38:
         python.version: '3.8'
+      Python39:
+        python.version: '3.9'
   steps:
     - template: .ci/azure-setup.yml
     - template: .ci/azure-steps.yml

--- a/pyacvd/_version.py
+++ b/pyacvd/_version.py
@@ -1,4 +1,11 @@
-"""Version number for pyacvd"""
+"""Version number for pyacvd
+
+On the ``main`` branch, use 'dev0' to denote a development version.
+For example:
+
+version_info = 0, 27, 'dev0'
+
+"""
 # major, minor, patch
-version_info = 0, 2, 6
+version_info = 0, 2, 'dev0'
 __version__ = '.'.join(map(str, version_info))

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -2,4 +2,3 @@ setuptools>=41.0.0
 wheel>=0.33.0
 numpy<1.20.0
 cython>=0.29.0
-vtk>=8.0.0

--- a/requirements_build.txt
+++ b/requirements_build.txt
@@ -1,5 +1,5 @@
 setuptools>=41.0.0
 wheel>=0.33.0
-numpy>=1.15.0
+numpy<1.20.0
 cython>=0.29.0
 vtk>=8.0.0


### PR DESCRIPTION
Addresses #18 by building with `numpy<1.20`.
