### PR TITLE
Remove OpenMP

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -31,6 +31,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: pip
+
     - name: Build sdist
       run: pipx run build --sdist
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.8
+  rev: v0.6.7
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
@@ -36,6 +36,6 @@ repos:
 
 # this validates our github workflow files
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.28.4
+  rev: 0.29.2
   hooks:
     - id: check-github-workflows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.15...3.26)
 
-project(nanobind_project LANGUAGES CXX)
-if(NOT APPLE)
-  find_package(OpenMP REQUIRED)
-endif()
-
 # Try to import all Python components potentially needed by nanobind
 find_package(Python 3.9
   REQUIRED COMPONENTS Interpreter Development.Module
@@ -28,23 +23,14 @@ nanobind_add_module(
   src/clustering.cpp
 )
 
-# Link OpenMP
-if(OpenMP_CXX_FOUND)
-  target_link_libraries(_clustering PRIVATE OpenMP::OpenMP_CXX)
-endif()
 
 # Compiler-specific options
 if(MSVC)
-  # Use MSVC optimization levels and OpenMP setup
-  target_compile_options(_clustering PRIVATE /O2 /std:c++17 /openmp:llvm)
-  # /openmp:llvm
+  # Use MSVC optimization levels
+  target_compile_options(_clustering PRIVATE /O2 /std:c++17)
 else()
   # Assuming GCC or Clang
-  if (APPLE)
-    target_compile_options(_clustering PRIVATE -O3)
-  else()
-    target_compile_options(_clustering PRIVATE -O3 -fopenmp)
-  endif()
+  target_compile_options(_clustering PRIVATE -O3)
 
 endif()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,7 @@ classifiers = [
 dependencies = [
   "numpy",
   "pyvista>=0.37.0",
-  'pykdtree<1.3.12; platform_system == "Darwin"',
-  'pykdtree; platform_system != "Darwin"'
+  'pykdtree',
 ]
 description = "Uniformly remeshes surface meshes"
 keywords = ["vtk", "uniform", "meshing", "remeshing", "acvd"]
@@ -35,6 +34,7 @@ archs = ["auto64"]  # 64-bit only
 skip = "cp38-* cp313-* pp* *musllinux*"  # build Python 3.9 - Python 3.13
 test-command = "pytest {project}/tests"
 test-requires = "pytest"
+test-skip = "*-macosx_arm64"
 
 [tool.cibuildwheel.macos]
 archs = ["native"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 dependencies = [
   "numpy",
   "pyvista>=0.37.0",
-  "pykdtree"
+  'pykdtree<1.3.12; platform_system == "Darwin"',
+  'pykdtree; platform_system != "Darwin"'
 ]
 description = "Uniformly remeshes surface meshes"
 keywords = ["vtk", "uniform", "meshing", "remeshing", "acvd"]

--- a/src/clustering.cpp
+++ b/src/clustering.cpp
@@ -524,7 +524,6 @@ nb::tuple PointWeights(
             local_pweight[point2] += farea_l;
         }
 
-#pragma omp critical
         for (size_t i = 0; i < n_points; i++) {
             pweight[i] += local_pweight[i];
         }


### PR DESCRIPTION
Resolve #56 by removing [OpenMP](https://www.openmp.org/).

This will reduce the performance in node normal and face normal calculation, but not the main clustering operations.

Also:
- Fix source distribution CI
- Disable testing on MacOS ARM due to pykdtree OpenMP issue. Plan to revert this.